### PR TITLE
Fix docker dns lookup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "5432:5432"
     volumes:
       - ./internal/model/sql/postgres/schema:/docker-entrypoint-initdb.d
+    networks:
+      - hellper
   hellper:
     image: golang:1.13
     volumes:
@@ -22,8 +24,9 @@ services:
       - "8080:8080"
     depends_on:
       - hellper_db
+    networks:
+      - hellper
 networks:
-  default:
-    driver: bridge
+    hellper:
 
 


### PR DESCRIPTION
### Description
<!--- Provide a minimal description of the changes or addition you are proposing in your pull request. -->
<!--- If it is related with a bug/issue fix, do not forget to link the issue in the description. -->
When running the bot, it was throwing an error about not being able to lookup for the database name in the local dns. This fixes this problem.
