### PR TITLE
Fix notify broken build

### DIFF
--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
+	ctx        = context.Background()
 	logger     = internal.NewLogger()
-	client     = internal.NewClient(logger)
-	repository = internal.NewRepository(logger)
+	client     = internal.NewClient(ctx, logger)
+	repository = internal.NewIncidentRepository(ctx, logger)
 
 	arg opt
 )


### PR DESCRIPTION
Since it's other program, our build of the API didn't catch the compilation errors.