### PR TITLE
Refactor dependencies into a wrapper struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.13
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/Sirupsen/logrus v0.0.0-00010101000000-000000000000 // indirect
+	github.com/docker/docker v1.13.1
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/joho/godotenv v1.3.0
@@ -18,3 +20,5 @@ require (
 	golang.org/x/tools v0.0.0-20201202200335-bef1c476418a // indirect
 	google.golang.org/api v0.35.0
 )
+
+replace github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
+github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -146,6 +148,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/slack-go/slack v0.7.2 h1:oLy2a2YqrtoHSSxbjRhrtLDGbCKcZJwgbuQ826BWxaI=
 github.com/slack-go/slack v0.7.2/go.mod h1:FGqNzJBmxIsZURAxh2a8D21AnOVvvXZvGligs4npPUM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -281,6 +285,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -300,6 +305,7 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642 h1:B6caxRw+hozq68X2MY7jEpZh/
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f h1:Fqb3ao1hUmOR3GkUOg/Y+BadLwykBIzs5q8Ez2SbHyc=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,4 +1,4 @@
-package internal
+package app
 
 import (
 	"context"

--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -1,4 +1,4 @@
-package internal
+package app
 
 const LoggerZap = "zap"
 const ClientSlack = "slack"

--- a/internal/commands/cancel_test.go
+++ b/internal/commands/cancel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"hellper/internal/app"
 	"hellper/internal/bot"
 	"hellper/internal/commands"
 	"hellper/internal/log"
@@ -20,10 +21,8 @@ type cancelCommandFixture struct {
 	expectError  bool
 	errorMessage string
 
-	ctx            context.Context
-	mockLogger     log.Logger
-	mockClient     bot.Client
-	mockRepository model.IncidentRepository
+	ctx context.Context
+	app *app.App
 
 	channelID   string
 	userID      string
@@ -90,10 +89,11 @@ func (f *cancelCommandFixture) setup(t *testing.T) {
 		f.channelID,
 	).Return(nil)
 
-	f.mockLogger = loggerMock
-	f.mockClient = clientMock
-	f.mockRepository = repositoryMock
-
+	f.app = &app.App{
+		Logger:             loggerMock,
+		Client:             clientMock,
+		IncidentRepository: repositoryMock,
+	}
 }
 func TestOpenCancelIncidentDialog(t *testing.T) {
 	table := []cancelCommandFixture{
@@ -121,9 +121,7 @@ func TestOpenCancelIncidentDialog(t *testing.T) {
 
 			err := commands.OpenCancelIncidentDialog(
 				f.ctx,
-				f.mockLogger,
-				f.mockClient,
-				f.mockRepository,
+				f.app,
 				f.channelID,
 				f.userID,
 				f.triggerID,
@@ -164,9 +162,7 @@ func TestCancelIncidentByDialog(t *testing.T) {
 
 			err := commands.CancelIncidentByDialog(
 				f.ctx,
-				f.mockLogger,
-				f.mockClient,
-				f.mockRepository,
+				f.app,
 				f.mockDetails,
 			)
 

--- a/internal/commands/event_executor.go
+++ b/internal/commands/event_executor.go
@@ -3,24 +3,19 @@ package commands
 import (
 	"context"
 
-	"hellper/internal/bot"
+	"hellper/internal/app"
 	"hellper/internal/log"
-	"hellper/internal/model"
 )
 
 // EventExecutor represents the executor struct that is used to execute an event command
 type EventExecutor struct {
-	logger     log.Logger
-	client     bot.Client
-	repository model.IncidentRepository
+	app *app.App
 }
 
 // NewEventExecutor initialize a new EventExecutor type
-func NewEventExecutor(logger log.Logger, client bot.Client, repository model.IncidentRepository) *EventExecutor {
+func NewEventExecutor(app *app.App) *EventExecutor {
 	return &EventExecutor{
-		logger:     logger,
-		client:     client,
-		repository: repository,
+		app: app,
 	}
 }
 
@@ -28,17 +23,17 @@ func NewEventExecutor(logger log.Logger, client bot.Client, repository model.Inc
 func (e *EventExecutor) ExecuteEventCommand(
 	ctx context.Context, cmdLine string, event TriggerEvent,
 ) error {
-	e.logger.Info(
+	e.app.Logger.Info(
 		ctx,
 		"command/eventexecutor.ExecuteEventCommand",
 		log.NewValue("command_line", cmdLine),
 		log.NewValue("event", event),
 	)
 
-	invoker := newEventInvoker(e.logger, e.client, e.repository)
+	invoker := newEventInvoker(e.app)
 	err := invoker.eventInvoker(ctx, cmdLine, event)
 	if err != nil {
-		e.logger.Error(
+		e.app.Logger.Error(
 			ctx,
 			"command/eventexecutor.ExecuteEventCommand command_result",
 			log.NewValue("command_line", cmdLine),

--- a/internal/commands/event_invoker.go
+++ b/internal/commands/event_invoker.go
@@ -6,15 +6,12 @@ import (
 	"regexp"
 	"strings"
 
-	"hellper/internal/bot"
+	"hellper/internal/app"
 	"hellper/internal/log"
-	"hellper/internal/model"
 )
 
 type eventInvoker struct {
-	logger     log.Logger
-	client     bot.Client
-	repository model.IncidentRepository
+	app *app.App
 }
 
 var (
@@ -38,29 +35,19 @@ func parseCommandLine(cmdLine string) (string, string, error) {
 	return matches[3], matches[4], nil
 }
 
-func newEventInvoker(
-	logger log.Logger, client bot.Client, repository model.IncidentRepository,
-) *eventInvoker {
+func newEventInvoker(app *app.App) *eventInvoker {
 	return &eventInvoker{
-		logger:     logger,
-		client:     client,
-		repository: repository,
+		app: app,
 	}
 }
 
 func (e *eventInvoker) eventInvoker(ctx context.Context, cmdLine string, event TriggerEvent) error {
-	var (
-		logger     = e.logger
-		client     = e.client
-		repository = e.repository
-	)
-
 	cmd, args, err := parseCommandLine(cmdLine)
 	if err != nil {
 		return err
 	}
 
-	logger.Info(
+	e.app.Logger.Info(
 		ctx,
 		"command/event_invoker.eventInvoker",
 		log.NewValue("command", cmd),
@@ -70,11 +57,11 @@ func (e *eventInvoker) eventInvoker(ctx context.Context, cmdLine string, event T
 
 	switch cmd {
 	case "", "help":
-		help(ctx, client, logger, event.Channel)
+		help(ctx, e.app, event.Channel)
 	case "ping":
-		ping(ctx, client, logger, event.Channel)
+		ping(ctx, e.app, event.Channel)
 	case "list":
-		ListOpenIncidents(ctx, client, logger, repository, event)
+		ListOpenIncidents(ctx, e.app, event)
 	}
 	return err
 }

--- a/internal/commands/list_open.go
+++ b/internal/commands/list_open.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"context"
-	"hellper/internal/bot"
+	"hellper/internal/app"
 	"hellper/internal/log"
 	"hellper/internal/model"
 	"strings"
@@ -11,21 +11,21 @@ import (
 )
 
 //ListOpenIncidents get the currently opened incidents and return the channel_name of each one of them.
-func ListOpenIncidents(ctx context.Context, client bot.Client, logger log.Logger, repository model.IncidentRepository, event TriggerEvent) {
+func ListOpenIncidents(ctx context.Context, app *app.App, event TriggerEvent) {
 
-	incidents, err := repository.ListActiveIncidents(ctx)
+	incidents, err := app.IncidentRepository.ListActiveIncidents(ctx)
 	if err != nil {
-		logger.Error(
+		app.Logger.Error(
 			ctx,
 			"command/list_open.ListOpenIncidents ListActiveIncidents error",
 			log.NewValue("event", event),
 			log.NewValue("error", err),
 		)
 
-		PostErrorAttachment(ctx, client, logger, event.Channel, event.User, err.Error())
+		PostErrorAttachment(ctx, app, event.Channel, event.User, err.Error())
 	}
 
-	logger.Info(
+	app.Logger.Info(
 		ctx,
 		"command/list_open.ListOpenIncidents",
 		log.NewValue("event", event),
@@ -37,7 +37,7 @@ func ListOpenIncidents(ctx context.Context, client bot.Client, logger log.Logger
 		messageText.WriteString("No active incidents!")
 	} else {
 		attachment := createListOpenAttachment(incidents)
-		postMessage(client, event.Channel, "", attachment)
+		postMessage(app, event.Channel, "", attachment)
 	}
 }
 

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"context"
 
-	"hellper/internal/bot"
+	"hellper/internal/app"
 	"hellper/internal/log"
 	"hellper/internal/model"
 
@@ -12,14 +12,13 @@ import (
 
 func getSlackUserInfo(
 	ctx context.Context,
-	client bot.Client,
-	logger log.Logger,
+	app *app.App,
 	userID string,
 ) (*model.User, error) {
 
-	slackUser, err := client.GetUserInfoContext(ctx, userID)
+	slackUser, err := app.Client.GetUserInfoContext(ctx, userID)
 	if err != nil {
-		logger.Error(
+		app.Logger.Error(
 			ctx,
 			"command/user.getSlackUserInfo error",
 			log.NewValue("userID", userID),
@@ -40,11 +39,10 @@ func getSlackUserInfo(
 
 func getUsersIDsInConversation(
 	ctx context.Context,
-	client bot.Client,
-	logger log.Logger,
+	app *app.App,
 	channelID string,
 ) (*[]string, error) {
-	logger.Info(
+	app.Logger.Info(
 		ctx,
 		"command/user.getUsersInConversation",
 		log.NewValue("params", channelID),
@@ -57,9 +55,9 @@ func getUsersIDsInConversation(
 	var members []string
 
 	for {
-		list, cursor, err := client.GetUsersInConversationContext(ctx, &params)
+		list, cursor, err := app.Client.GetUsersInConversationContext(ctx, &params)
 		if err != nil {
-			logger.Error(
+			app.Logger.Error(
 				ctx,
 				"command/user.getUsersIDsInConversation",
 				log.NewValue("channelID", channelID),
@@ -80,15 +78,14 @@ func getUsersIDsInConversation(
 
 func getUsersInConversation(
 	ctx context.Context,
-	client bot.Client,
-	logger log.Logger,
+	app *app.App,
 	channelID string,
 ) (*[]model.User, error) {
 	var users []model.User
 
-	usersIDs, err := getUsersIDsInConversation(ctx, client, logger, channelID)
+	usersIDs, err := getUsersIDsInConversation(ctx, app, channelID)
 	if err != nil {
-		logger.Error(
+		app.Logger.Error(
 			ctx,
 			"command/user.getUsersInConversation",
 			log.NewValue("channel_id", channelID),
@@ -98,9 +95,9 @@ func getUsersInConversation(
 	}
 
 	for _, id := range *usersIDs {
-		user, err := getSlackUserInfo(ctx, client, logger, id)
+		user, err := getSlackUserInfo(ctx, app, id)
 		if err != nil {
-			logger.Error(
+			app.Logger.Error(
 				ctx,
 				"command/user.getUsersInConversation",
 				log.NewValue("user_id", id),
@@ -116,15 +113,14 @@ func getUsersInConversation(
 
 func getUsersEmailsInConversation(
 	ctx context.Context,
-	client bot.Client,
-	logger log.Logger,
+	app *app.App,
 	channelID string,
 ) (*[]string, error) {
 	var emails []string
 
-	users, err := getUsersInConversation(ctx, client, logger, channelID)
+	users, err := getUsersInConversation(ctx, app, channelID)
 	if err != nil {
-		logger.Error(
+		app.Logger.Error(
 			ctx,
 			"command/user.getUsersEmailsInConversation",
 			log.NewValue("channel_id", channelID),

--- a/internal/handler/callback_event.go
+++ b/internal/handler/callback_event.go
@@ -3,16 +3,15 @@ package handler
 import (
 	"context"
 
-	"hellper/internal/bot"
+	"hellper/internal/app"
 	"hellper/internal/commands"
 	"hellper/internal/log"
-	"hellper/internal/model"
 
 	"github.com/slack-go/slack/slackevents"
 )
 
 func replyCallbackEvent(
-	ctx context.Context, logger log.Logger, client bot.Client, repository model.IncidentRepository, event slackevents.EventsAPIEvent,
+	ctx context.Context, app *app.App, event slackevents.EventsAPIEvent,
 ) error {
 	var (
 		innerEvent = event.InnerEvent
@@ -24,7 +23,7 @@ func replyCallbackEvent(
 
 	switch callbackEvent := innerEvent.Data.(type) {
 	case *slackevents.AppMentionEvent:
-		logger.Info(
+		app.Logger.Info(
 			ctx,
 			"handler/event.appmention",
 			log.NewValue("callbackEvent", callbackEvent),
@@ -37,28 +36,28 @@ func replyCallbackEvent(
 			User:    callbackEvent.User,
 		}
 	case *slackevents.MessageEvent:
-		logger.Info(
+		app.Logger.Info(
 			ctx,
 			"handler/event.message",
 			log.NewValue("callbackEvent", callbackEvent),
 		)
 		return nil
 	case *slackevents.AppUninstalledEvent:
-		logger.Info(
+		app.Logger.Info(
 			ctx,
 			"handler/event.appunistalled",
 			log.NewValue("callbackEvent", callbackEvent),
 		)
 		return nil
 	case *slackevents.LinkSharedEvent:
-		logger.Info(
+		app.Logger.Info(
 			ctx,
 			"handler/event.linkshared",
 			log.NewValue("callbackEvent", callbackEvent),
 		)
 		return nil
 	default:
-		logger.Info(
+		app.Logger.Info(
 			ctx,
 			"handler/event.unkown_event",
 			log.NewValue("callbackEvent", callbackEvent),
@@ -66,7 +65,7 @@ func replyCallbackEvent(
 		return nil
 	}
 
-	executor := commands.NewEventExecutor(logger, client, repository)
+	executor := commands.NewEventExecutor(app)
 	err = executor.ExecuteEventCommand(ctx, cmdLine, trigger)
 	if err != nil {
 		return err

--- a/internal/handler/cancel.go
+++ b/internal/handler/cancel.go
@@ -4,30 +4,25 @@ import (
 	"bytes"
 	"net/http"
 
-	"hellper/internal/bot"
+	"hellper/internal/app"
 	"hellper/internal/commands"
 	"hellper/internal/log"
-	"hellper/internal/model"
 )
 
 type handlerCancel struct {
-	logger     log.Logger
-	client     bot.Client
-	repository model.IncidentRepository
+	app *app.App
 }
 
-func newHandlerCancel(logger log.Logger, client bot.Client, repository model.IncidentRepository) *handlerCancel {
+func newHandlerCancel(app *app.App) *handlerCancel {
 	return &handlerCancel{
-		logger:     logger,
-		client:     client,
-		repository: repository,
+		app: app,
 	}
 }
 
 func (h *handlerCancel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var (
 		ctx    = r.Context()
-		logger = h.logger
+		logger = h.app.Logger
 
 		formValues []log.Value
 		buf        bytes.Buffer
@@ -56,7 +51,7 @@ func (h *handlerCancel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	channelID := r.FormValue("channel_id")
 	userID := r.FormValue("user_id")
 
-	err := commands.OpenCancelIncidentDialog(ctx, logger, h.client, h.repository, channelID, userID, tiggerID)
+	err := commands.OpenCancelIncidentDialog(ctx, h.app, channelID, userID, tiggerID)
 	if err != nil {
 		logger.Error(
 			ctx,

--- a/internal/handler/close.go
+++ b/internal/handler/close.go
@@ -4,30 +4,25 @@ import (
 	"bytes"
 	"net/http"
 
-	"hellper/internal/bot"
+	"hellper/internal/app"
 	"hellper/internal/commands"
 	"hellper/internal/log"
-	"hellper/internal/model"
 )
 
 type handlerClose struct {
-	logger     log.Logger
-	client     bot.Client
-	repository model.IncidentRepository
+	app *app.App
 }
 
-func newHandlerClose(logger log.Logger, client bot.Client, repository model.IncidentRepository) *handlerClose {
+func newHandlerClose(app *app.App) *handlerClose {
 	return &handlerClose{
-		logger:     logger,
-		client:     client,
-		repository: repository,
+		app: app,
 	}
 }
 
 func (h *handlerClose) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var (
 		ctx    = r.Context()
-		logger = h.logger
+		logger = h.app.Logger
 
 		formValues []log.Value
 		buf        bytes.Buffer
@@ -55,7 +50,7 @@ func (h *handlerClose) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	channelID := r.FormValue("channel_id")
 	userID := r.FormValue("user_id")
 
-	err := commands.CloseIncidentDialog(ctx, logger, h.client, h.repository, channelID, userID, triggerID)
+	err := commands.CloseIncidentDialog(ctx, h.app, channelID, userID, triggerID)
 	if err != nil {
 		logger.Error(
 			ctx,

--- a/internal/handler/open.go
+++ b/internal/handler/open.go
@@ -4,37 +4,27 @@ import (
 	"bytes"
 	"net/http"
 
-	"hellper/internal/bot"
+	"hellper/internal/app"
 	"hellper/internal/commands"
 	"hellper/internal/log"
-	"hellper/internal/model"
 )
 
 type handlerOpen struct {
-	logger            log.Logger
-	client            bot.Client
-	repository        model.IncidentRepository
-	serviceRepository model.ServiceRepository
+	app *app.App
 }
 
 func newHandlerOpen(
-	logger log.Logger,
-	client bot.Client,
-	repository model.IncidentRepository,
-	serviceRepository model.ServiceRepository,
+	app *app.App,
 ) *handlerOpen {
 	return &handlerOpen{
-		logger:            logger,
-		client:            client,
-		repository:        repository,
-		serviceRepository: serviceRepository,
+		app: app,
 	}
 }
 
 func (h *handlerOpen) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var (
 		ctx    = r.Context()
-		logger = h.logger
+		logger = h.app.Logger
 
 		formValues []log.Value
 		buf        bytes.Buffer
@@ -60,7 +50,7 @@ func (h *handlerOpen) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	triggerID := r.FormValue("trigger_id")
 
-	err := commands.OpenStartIncidentDialog(ctx, h.client, h.serviceRepository, triggerID)
+	err := commands.OpenStartIncidentDialog(ctx, h.app, triggerID)
 	if err != nil {
 		logger.Error(
 			ctx,

--- a/internal/handler/pause_notify.go
+++ b/internal/handler/pause_notify.go
@@ -4,32 +4,24 @@ import (
 	"bytes"
 	"net/http"
 
-	"hellper/internal/bot"
+	"hellper/internal/app"
 	"hellper/internal/commands"
 	"hellper/internal/log"
-	"hellper/internal/model"
 )
 
 type handlerPauseNotify struct {
-	logger     log.Logger
-	client     bot.Client
-	repository model.IncidentRepository
+	app *app.App
 }
 
-func newHandlerPauseNotify(logger log.Logger, client bot.Client, repository model.IncidentRepository) *handlerPauseNotify {
+func newHandlerPauseNotify(app *app.App) *handlerPauseNotify {
 	return &handlerPauseNotify{
-		logger:     logger,
-		client:     client,
-		repository: repository,
+		app: app,
 	}
 }
 
 func (h *handlerPauseNotify) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var (
-		ctx        = r.Context()
-		logger     = h.logger
-		client     = h.client
-		repository = h.repository
+		ctx = r.Context()
 
 		buf        bytes.Buffer
 		formValues []log.Value
@@ -38,7 +30,7 @@ func (h *handlerPauseNotify) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.ParseForm()
 	buf.ReadFrom(r.Body)
 	body := buf.String()
-	logger.Info(
+	h.app.Logger.Info(
 		ctx,
 		"handler/pauseNotify.ServeHTTP",
 		log.NewValue("requestbody", body),
@@ -47,7 +39,7 @@ func (h *handlerPauseNotify) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for key, value := range r.Form {
 		formValues = append(formValues, log.NewValue(key, value))
 	}
-	logger.Info(
+	h.app.Logger.Info(
 		ctx,
 		"handler/pauseNotify.ServeHTTP Form",
 		formValues...,
@@ -57,9 +49,9 @@ func (h *handlerPauseNotify) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	userID := r.FormValue("user_id")
 	triggerID := r.FormValue("trigger_id")
 
-	err := commands.PauseNotifyIncidentDialog(ctx, logger, client, repository, channelID, userID, triggerID)
+	err := commands.PauseNotifyIncidentDialog(ctx, h.app, channelID, userID, triggerID)
 	if err != nil {
-		logger.Error(
+		h.app.Logger.Error(
 			ctx,
 			"handler/pauseNotify.ServeHTTP PauseNotifyIncidentDialog error",
 			log.NewValue("channelID", channelID),

--- a/internal/handler/route.go
+++ b/internal/handler/route.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"path"
 
-	"hellper/internal"
+	"hellper/internal/app"
 	"hellper/internal/bot"
 )
 
@@ -22,17 +22,16 @@ var (
 )
 
 func init() {
-	dependencies := internal.NewApp()
-	openHandler = newHandlerOpen(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository, dependencies.ServiceRepository)
-	eventsHandler = newHandlerEvents(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository)
-	interactiveHandler = newHandlerInteractive(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository,
-		dependencies.FileStorage, dependencies.Calendar)
-	statusHandler = newHandlerStatus(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository)
-	datesHandler = newHandlerDates(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository)
-	closeHandler = newHandlerClose(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository)
-	cancelHandler = newHandlerCancel(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository)
-	resolveHandler = newHandlerResolve(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository)
-	pauseNotifyHandler = newHandlerPauseNotify(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository)
+	dependencies := app.NewApp()
+	openHandler = newHandlerOpen(&dependencies)
+	eventsHandler = newHandlerEvents(&dependencies)
+	interactiveHandler = newHandlerInteractive(&dependencies)
+	statusHandler = newHandlerStatus(&dependencies)
+	datesHandler = newHandlerDates(&dependencies)
+	closeHandler = newHandlerClose(&dependencies)
+	cancelHandler = newHandlerCancel(&dependencies)
+	resolveHandler = newHandlerResolve(&dependencies)
+	pauseNotifyHandler = newHandlerPauseNotify(&dependencies)
 	// commands.StartAllReminderJobs(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository)
 }
 

--- a/internal/handler/route.go
+++ b/internal/handler/route.go
@@ -22,7 +22,7 @@ var (
 )
 
 func init() {
-	dependencies := internal.New()
+	dependencies := internal.NewApp()
 	openHandler = newHandlerOpen(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository, dependencies.ServiceRepository)
 	eventsHandler = newHandlerEvents(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository)
 	interactiveHandler = newHandlerInteractive(dependencies.Logger, dependencies.Client, dependencies.IncidentRepository,

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -17,7 +17,7 @@ import (
 	"hellper/internal/model/sql/postgres"
 )
 
-type MainInternal struct {
+type App struct {
 	Logger             log.Logger
 	Client             bot.Client
 	IncidentRepository model.IncidentRepository
@@ -26,10 +26,10 @@ type MainInternal struct {
 	Calendar           calendar.Calendar
 }
 
-func New() MainInternal {
+func NewApp() App {
 	ctx := context.Background()
 	logger := NewLogger()
-	return MainInternal{
+	return App{
 		Logger:             logger,
 		Client:             NewClient(ctx, logger),
 		IncidentRepository: NewIncidentRepository(ctx, logger),

--- a/internal/notify/channels-notify.go
+++ b/internal/notify/channels-notify.go
@@ -24,7 +24,7 @@ func channelsNotify(ctx context.Context) {
 		return
 	}
 
-	incidents, err := repository.ListActiveIncidents(ctx)
+	incidents, err := incidentRepository.ListActiveIncidents(ctx)
 	if err != nil {
 		logger.Error(ctx, log.Trace(), log.NewValue("error", err))
 	}
@@ -45,7 +45,7 @@ func channelsNotify(ctx context.Context) {
 }
 
 func notifyChannels(ctx context.Context, incident model.Incident, msg string) {
-	if reminder.CanSendNotify(ctx, client, logger, repository, incident) {
+	if reminder.CanSendNotify(ctx, client, logger, incidentRepository, incident) {
 		logger.Info(ctx, log.Trace(), log.Action("notify_job"), log.NewValue("incident", incident))
 		err := send(incident.ChannelId, msg)
 		if err != nil {

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"hellper/internal"
+	"hellper/internal/app"
 	"hellper/internal/config"
 	"hellper/internal/log"
 	"hellper/internal/model"
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	logger     = internal.NewLogger()
-	client     = internal.NewClient(logger)
-	repository = internal.NewRepository(logger)
+	ctx                = context.Background()
+	logger             = app.NewLogger()
+	client             = app.NewClient(ctx, logger)
+	incidentRepository = app.NewIncidentRepository(ctx, logger)
 
 	arg opt
 )


### PR DESCRIPTION
Now instead of passing multiple dependencies one by one, we can just pass an `app.App` instance and it contains all dependencies already initialized.