### PR TITLE
Make ResolveIncident and CloseIncident more minimalist

### DIFF
--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -2,12 +2,12 @@ package commands
 
 import (
 	"context"
-	"database/sql"
 	"hellper/internal/app"
 	"hellper/internal/concurrence"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"hellper/internal/bot"
 	"hellper/internal/config"
@@ -33,34 +33,26 @@ func CloseIncidentDialog(ctx context.Context, app *app.App, channelID, userID, t
 		return err
 	}
 
-	if inc.StartTimestamp == nil {
-		var (
-			messageText strings.Builder
-		)
-
-		messageText.WriteString("The dates of Incident <#" + inc.ChannelId + "> have not been updated yet.\n" +
-			"Please, call the command `/hellper_update_dates` to receive the current dates and update each one.")
-
-		attch := slack.Attachment{
-			Pretext:  "",
-			Fallback: messageText.String(),
-			Text: "The dates of Incident <#" + inc.ChannelId + "> have not been updated yet.\n" +
-				"Please, call the command `/hellper_update_dates` to receive the current dates and update each one.",
-			Color:  "#ff8c00",
-			Fields: []slack.AttachmentField{},
-		}
-
-		return postMessage(app, channelID, "", attch)
-	}
-
-	feature := &slack.TextInputElement{
+	rootCause := &slack.TextInputElement{
 		DialogInput: slack.DialogInput{
-			Label:       "Feature",
-			Name:        "feature",
-			Type:        "text",
-			Placeholder: "Feature",
+			Label:       "Root Cause",
+			Name:        "root_cause",
+			Type:        "textarea",
+			Placeholder: "Incident root cause description.",
 			Optional:    false,
 		},
+		MaxLength: 500,
+	}
+	startDate := &slack.TextInputElement{
+		DialogInput: slack.DialogInput{
+			Label:       "Incident start date (UTC)",
+			Name:        "init_date",
+			Type:        "text",
+			Placeholder: dateLayout,
+			Hint:        "The time is in format " + dateLayout + " and UTC timezone",
+			Optional:    false,
+		},
+		Value: "",
 	}
 	severityLevel := &slack.DialogInputSelect{
 		DialogInput: slack.DialogInput{
@@ -68,7 +60,7 @@ func CloseIncidentDialog(ctx context.Context, app *app.App, channelID, userID, t
 			Name:        "severity_level",
 			Type:        "select",
 			Placeholder: "Set the severity level",
-			Optional:    false,
+			Optional:    true,
 		},
 		Options: []slack.DialogSelectOption{
 			{
@@ -90,70 +82,21 @@ func CloseIncidentDialog(ctx context.Context, app *app.App, channelID, userID, t
 		},
 		OptionGroups: []slack.DialogOptionGroup{},
 	}
-	responsibility := &slack.DialogInputSelect{
-		DialogInput: slack.DialogInput{
-			Label:       "Responsibility",
-			Name:        "responsibility",
-			Type:        "select",
-			Placeholder: "Set the responsible",
-			Optional:    false,
-		},
-		Value: "0",
-		Options: []slack.DialogSelectOption{
-			{
-				Label: "Product",
-				Value: "0",
-			},
-			{
-				Label: "Third-Party",
-				Value: "1",
-			},
-		},
-		OptionGroups: []slack.DialogOptionGroup{},
+
+	dialogElements := []slack.DialogElement{
+		rootCause,
 	}
-	team := &slack.TextInputElement{
-		DialogInput: slack.DialogInput{
-			Label:       "Owner team",
-			Name:        "owner_team",
-			Type:        "text",
-			Placeholder: "Team (i.e. Mushin, Hydra, POPE)",
-			Optional:    false,
-		},
+	if inc.StartTimestamp == nil {
+		dialogElements = append(dialogElements, startDate)
 	}
-	rootCause := &slack.TextInputElement{
-		DialogInput: slack.DialogInput{
-			Label:       "Root Cause",
-			Name:        "root_cause",
-			Type:        "textarea",
-			Placeholder: "Incident root cause description.",
-			Optional:    false,
-		},
-		MaxLength: 500,
-	}
-	impact := &slack.TextInputElement{
-		DialogInput: slack.DialogInput{
-			Label:       "Impact of incident",
-			Name:        "impact",
-			Type:        "text",
-			Placeholder: "Number of impacted accounts.",
-			Optional:    false,
-		},
-		Subtype: slack.InputSubtypeNumber,
-	}
+	dialogElements = append(dialogElements, severityLevel)
 
 	dialog := slack.Dialog{
 		CallbackID:     "inc-close",
 		Title:          "Close an Incident",
 		SubmitLabel:    "Close",
 		NotifyOnCancel: false,
-		Elements: []slack.DialogElement{
-			impact,
-			team,
-			feature,
-			severityLevel,
-			responsibility,
-			rootCause,
-		},
+		Elements:       dialogElements,
 	}
 
 	return app.Client.OpenDialog(triggerID, dialog)
@@ -168,39 +111,78 @@ func CloseIncidentByDialog(ctx context.Context, app *app.App, incidentDetails bo
 	)
 
 	var (
-		customerImpact   sql.NullInt64
 		channelID        = incidentDetails.Channel.ID
 		userID           = incidentDetails.User.ID
 		userName         = incidentDetails.User.Name
 		submissions      = incidentDetails.Submission
-		impact           = submissions.Impact
-		team             = submissions.Team
-		feature          = submissions.Feature
-		severityLevel    = submissions.SeverityLevel
-		responsibility   = getResponsabilityText(submissions.Responsibility)
 		rootCause        = submissions.RootCause
+		initDateText     = submissions.InitDate
+		severityLevel    = submissions.SeverityLevel
 		notifyOnClose    = config.Env.NotifyOnClose
 		productChannelID = config.Env.ProductChannelID
+
+		initDate time.Time
 	)
 
-	severityLevelInt64, err := getStringInt64(severityLevel)
+	var err error
+	if initDateText != "" {
+		initDate, err = time.ParseInLocation(dateLayout, initDateText, time.UTC)
+		if err != nil {
+			app.Logger.Error(
+				ctx,
+				"command/dates.UpdateDatesByDialog ParseInLocation start date ERROR",
+				log.NewValue("channelID", channelID),
+				log.NewValue("timeZoneString", "UTC"),
+				log.NewValue("initDateText", initDateText),
+				log.NewValue("error", err),
+			)
+			PostErrorAttachment(ctx, app, channelID, userID, err.Error())
+			return err
+		}
+	}
+
+	severityLevelInt64 := int64(-1)
+	if severityLevel != "" {
+		severityLevelInt64, err = getStringInt64(severityLevel)
+	}
 	if err != nil {
 		return err
 	}
 
-	customerImpact.Int64, err = getStringInt64(impact)
+	inc, err := app.IncidentRepository.GetIncident(ctx, channelID)
 	if err != nil {
+		app.Logger.Error(
+			ctx,
+			log.Trace(),
+			log.Reason("GetIncident"),
+			log.NewValue("channelID", channelID),
+			log.NewValue("error", err),
+		)
+		PostErrorAttachment(ctx, app, channelID, userID, err.Error())
+		return err
+	}
+
+	ownerTeamName, err := app.ServiceRepository.GetServiceInstanceOwnerTeamName(ctx, inc.Product)
+	if err != nil {
+		app.Logger.Error(
+			ctx,
+			log.Trace(),
+			log.Reason("GetServiceInstanceOwnerTeamName"),
+			log.NewValue("channelID", channelID),
+			log.NewValue("error", err),
+		)
 		return err
 	}
 
 	incident := model.Incident{
 		RootCause:      rootCause,
-		Functionality:  feature,
-		Team:           team,
-		CustomerImpact: customerImpact,
+		StartTimestamp: &initDate,
+		Team:           ownerTeamName,
 		SeverityLevel:  severityLevelInt64,
-		Responsibility: responsibility,
 		ChannelId:      channelID,
+	}
+	if initDateText != "" {
+		incident.StartTimestamp = &initDate
 	}
 
 	err = app.IncidentRepository.CloseIncident(ctx, &incident)
@@ -215,7 +197,7 @@ func CloseIncidentByDialog(ctx context.Context, app *app.App, incidentDetails bo
 		return err
 	}
 
-	inc, err := app.IncidentRepository.GetIncident(ctx, channelID)
+	inc, err = app.IncidentRepository.GetIncident(ctx, channelID)
 	if err != nil {
 		app.Logger.Error(
 			ctx,
@@ -227,7 +209,7 @@ func CloseIncidentByDialog(ctx context.Context, app *app.App, incidentDetails bo
 		return err
 	}
 
-	channelAttachment := createCloseChannelAttachment(inc, userName, impact)
+	channelAttachment := createCloseChannelAttachment(inc, userName)
 	privateAttachment := createClosePrivateAttachment(inc)
 	message := "The Incident <#" + inc.ChannelId + "> has been closed by <@" + userName + ">"
 
@@ -271,24 +253,11 @@ func CloseIncidentByDialog(ctx context.Context, app *app.App, incidentDetails bo
 	return nil
 }
 
-func getResponsabilityText(r string) string {
-	switch r {
-	case "0":
-		return "Product"
-	case "1":
-		return "Third-Party"
-	}
-	return ""
-}
-
-func createCloseChannelAttachment(inc model.Incident, userName, impact string) slack.Attachment {
+func createCloseChannelAttachment(inc model.Incident, userName string) slack.Attachment {
 	var messageText strings.Builder
 	messageText.WriteString("The Incident <#" + inc.ChannelId + "> has been closed by <@" + userName + ">\n\n")
 	messageText.WriteString("*Team:* <#" + inc.Team + ">\n")
-	messageText.WriteString("*Feature:* `" + inc.Functionality + "`\n")
-	messageText.WriteString("*Impact:* `" + impact + "`\n")
 	messageText.WriteString("*Severity:* `" + getSeverityLevelText(inc.SeverityLevel) + "`\n")
-	messageText.WriteString("*Responsibility:* `" + inc.Responsibility + "`\n")
 	messageText.WriteString("*Root cause:* `" + inc.RootCause + "`\n\n")
 
 	return slack.Attachment{
@@ -314,20 +283,8 @@ func createCloseChannelAttachment(inc model.Incident, userName, impact string) s
 				Value: inc.Team,
 			},
 			{
-				Title: "Feature",
-				Value: inc.Functionality,
-			},
-			{
-				Title: "Impact",
-				Value: impact,
-			},
-			{
 				Title: "Severity",
 				Value: getSeverityLevelText(inc.SeverityLevel),
-			},
-			{
-				Title: "Responsibility",
-				Value: inc.Responsibility,
 			},
 			{
 				Title: "RootCause",
@@ -339,19 +296,12 @@ func createCloseChannelAttachment(inc model.Incident, userName, impact string) s
 
 func createClosePrivateAttachment(inc model.Incident) slack.Attachment {
 	var privateText strings.Builder
-	privateText.WriteString("The Incident <#" + inc.ChannelId + "> has been resolved by you\n\n")
-	privateText.WriteString("*Status.io:* Be sure to close the incident on https://status.io\n\n")
+	privateText.WriteString("The Incident <#" + inc.ChannelId + "> has been closed by you\n\n")
 
 	return slack.Attachment{
 		Pretext:  "The Incident <#" + inc.ChannelId + "> has been closed by you",
 		Fallback: privateText.String(),
 		Text:     "",
 		Color:    "#FE4D4D",
-		Fields: []slack.AttachmentField{
-			{
-				Title: "Status.io",
-				Value: "Be sure to close the incident on status.io",
-			},
-		},
 	}
 }

--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -116,24 +116,24 @@ func CloseIncidentByDialog(ctx context.Context, app *app.App, incidentDetails bo
 		userName         = incidentDetails.User.Name
 		submissions      = incidentDetails.Submission
 		rootCause        = submissions.RootCause
-		initDateText     = submissions.InitDate
+		startDateText    = submissions.InitDate
 		severityLevel    = submissions.SeverityLevel
 		notifyOnClose    = config.Env.NotifyOnClose
 		productChannelID = config.Env.ProductChannelID
 
-		initDate time.Time
+		startDate time.Time
 	)
 
 	var err error
-	if initDateText != "" {
-		initDate, err = time.ParseInLocation(dateLayout, initDateText, time.UTC)
+	if startDateText != "" {
+		startDate, err = time.ParseInLocation(dateLayout, startDateText, time.UTC)
 		if err != nil {
 			app.Logger.Error(
 				ctx,
-				"command/dates.UpdateDatesByDialog ParseInLocation start date ERROR",
+				"command/close.CloseIncidentByDialog ParseInLocation start date ERROR",
 				log.NewValue("channelID", channelID),
 				log.NewValue("timeZoneString", "UTC"),
-				log.NewValue("initDateText", initDateText),
+				log.NewValue("startDateText", startDateText),
 				log.NewValue("error", err),
 			)
 			PostErrorAttachment(ctx, app, channelID, userID, err.Error())
@@ -176,13 +176,13 @@ func CloseIncidentByDialog(ctx context.Context, app *app.App, incidentDetails bo
 
 	incident := model.Incident{
 		RootCause:      rootCause,
-		StartTimestamp: &initDate,
+		StartTimestamp: &startDate,
 		Team:           ownerTeamName,
 		SeverityLevel:  severityLevelInt64,
 		ChannelId:      channelID,
 	}
-	if initDateText != "" {
-		incident.StartTimestamp = &initDate
+	if startDateText != "" {
+		incident.StartTimestamp = &startDate
 	}
 
 	err = app.IncidentRepository.CloseIncident(ctx, &incident)

--- a/internal/commands/dates.go
+++ b/internal/commands/dates.go
@@ -13,10 +13,11 @@ import (
 	"github.com/slack-go/slack"
 )
 
+const dateLayout = "02/01/2006 15:04:05"
+
 // UpdateDatesDialog opens a dialog on Slack, so the user can update the dates of an incident
 func UpdateDatesDialog(ctx context.Context, app *app.App, channelID string, userID string, triggerID string) error {
 	var (
-		dateLayout          = "02/01/2006 15:04:05"
 		initValue           = ""
 		identificationValue = ""
 		endValue            = ""

--- a/internal/commands/dates_test.go
+++ b/internal/commands/dates_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"hellper/internal/app"
 	"hellper/internal/bot"
 	"hellper/internal/log"
 	"hellper/internal/model"
@@ -21,10 +22,10 @@ type datesCommandFixture struct {
 	expectError  bool
 	errorMessage string
 
-	ctx            context.Context
-	mockLogger     log.Logger
-	mockClient     bot.Client
-	mockrepository model.IncidentRepository
+	ctx                    context.Context
+	mockLogger             log.Logger
+	mockClient             bot.Client
+	mockIncidentRepository model.IncidentRepository
 
 	mockIncident             model.Incident
 	getIncidentError         error
@@ -57,7 +58,7 @@ func (f *datesCommandFixture) setup(t *testing.T) {
 
 	f.mockLogger = loggerMock
 	f.mockClient = clientMock
-	f.mockrepository = repositoryMock
+	f.mockIncidentRepository = repositoryMock
 }
 
 func TestUpdateDatesDialog(t *testing.T) {
@@ -84,7 +85,15 @@ func TestUpdateDatesDialog(t *testing.T) {
 		t.Run(fmt.Sprintf("%v-%v", index, f.testName), func(t *testing.T) {
 			f.setup(t)
 
-			err := UpdateDatesDialog(f.ctx, f.mockLogger, f.mockClient, f.mockrepository, f.channelID, f.userID, f.triggerID)
+			err := UpdateDatesDialog(
+				f.ctx,
+				&app.App{
+					Logger:             f.mockLogger,
+					Client:             f.mockClient,
+					IncidentRepository: f.mockIncidentRepository,
+				},
+				f.channelID, f.userID, f.triggerID,
+			)
 
 			if f.expectError {
 				if err == nil {
@@ -164,7 +173,15 @@ func TestUpdateDatesByDialog(t *testing.T) {
 		t.Run(fmt.Sprintf("%v-%v", index, f.testName), func(t *testing.T) {
 			f.setup(t)
 
-			err := UpdateDatesByDialog(f.ctx, f.mockClient, f.mockLogger, f.mockrepository, f.incidentDetails)
+			err := UpdateDatesByDialog(
+				f.ctx,
+				&app.App{
+					Logger:             f.mockLogger,
+					Client:             f.mockClient,
+					IncidentRepository: f.mockIncidentRepository,
+				},
+				f.incidentDetails,
+			)
 
 			if f.expectError {
 				if err == nil {

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -34,7 +34,7 @@ func OpenStartIncidentDialog(ctx context.Context, app *app.App, triggerID string
 	// the open command will fail and will give no feedback whatsoever for the user.
 	for len(services) < minimumNumberServices {
 		services = append(services, &model.ServiceInstance{
-			ID:   0,
+			ID:   "-",
 			Name: "-",
 		})
 	}
@@ -42,7 +42,7 @@ func OpenStartIncidentDialog(ctx context.Context, app *app.App, triggerID string
 	for _, service := range services {
 		serviceList = append(serviceList, slack.DialogSelectOption{
 			Label: service.Name,
-			Value: fmt.Sprintf("%d", service.ID),
+			Value: service.Name,
 		})
 	}
 

--- a/internal/commands/resolve.go
+++ b/internal/commands/resolve.go
@@ -34,7 +34,7 @@ func ResolveIncidentDialog(app *app.App, triggerID string) error {
 
 	postMortemMeeting := &slack.DialogInputSelect{
 		DialogInput: slack.DialogInput{
-			Label:       "Schedule a Post Mortem meeting?",
+			Label:       "Should I schedule a Post Mortem meeting?",
 			Name:        "post_mortem_meeting",
 			Type:        "select",
 			Placeholder: "Post Mortem Meeting",

--- a/internal/commands/resolve.go
+++ b/internal/commands/resolve.go
@@ -23,28 +23,18 @@ var patternStringDate = "2013-04-01 22:43"
 func ResolveIncidentDialog(app *app.App, triggerID string) error {
 	description := &slack.TextInputElement{
 		DialogInput: slack.DialogInput{
-			Label:       "Description",
+			Label:       "Solution Description",
 			Name:        "incident_description",
 			Type:        "textarea",
-			Placeholder: "Description eg. The incident was resolved after #PR fix",
+			Placeholder: "Brief description on what was done to solve this incident. eg. The incident was solved in PR #42",
 			Optional:    false,
 		},
 		MaxLength: 500,
 	}
-	statusIO := &slack.TextInputElement{
-		DialogInput: slack.DialogInput{
-			Label:       "Status.io link",
-			Name:        "status_io",
-			Type:        "text",
-			Placeholder: "status.io/xxxx",
-			Optional:    false,
-		},
-		Subtype: slack.InputSubtypeURL,
-	}
 
 	postMortemMeeting := &slack.DialogInputSelect{
 		DialogInput: slack.DialogInput{
-			Label:       "Can I schedule a Post Mortem meeting?",
+			Label:       "Schedule a Post Mortem meeting?",
 			Name:        "post_mortem_meeting",
 			Type:        "select",
 			Placeholder: "Post Mortem Meeting",
@@ -64,16 +54,19 @@ func ResolveIncidentDialog(app *app.App, triggerID string) error {
 		OptionGroups: []slack.DialogOptionGroup{},
 	}
 
+	dialogElements := []slack.DialogElement{
+		description,
+	}
+	if app.Calendar != nil {
+		dialogElements = append(dialogElements, postMortemMeeting)
+	}
+
 	dialog := slack.Dialog{
 		CallbackID:     "inc-resolve",
 		Title:          "Resolve an Incident",
 		SubmitLabel:    "Resolve",
 		NotifyOnCancel: false,
-		Elements: []slack.DialogElement{
-			statusIO,
-			description,
-			postMortemMeeting,
-		},
+		Elements:       dialogElements,
 	}
 
 	return app.Client.OpenDialog(triggerID, dialog)
@@ -99,7 +92,6 @@ func ResolveIncidentByDialog(
 		userName          = incidentDetails.User.Name
 		submissions       = incidentDetails.Submission
 		description       = submissions.IncidentDescription
-		statusPageURL     = submissions.StatusIO
 		postMortemMeeting = submissions.PostMortemMeeting
 		notifyOnResolve   = config.Env.NotifyOnResolve
 		productChannelID  = config.Env.ProductChannelID
@@ -111,7 +103,6 @@ func ResolveIncidentByDialog(
 		ChannelId:           channelID,
 		EndTimestamp:        &now,
 		DescriptionResolved: description,
-		StatusPageUrl:       statusPageURL,
 	}
 
 	err := app.IncidentRepository.ResolveIncident(ctx, &incident)
@@ -138,15 +129,18 @@ func ResolveIncidentByDialog(
 		return err
 	}
 
-	hasPostMortemMeeting, err := strconv.ParseBool(postMortemMeeting)
-	if err != nil {
-		app.Logger.Error(
-			ctx,
-			log.Trace(),
-			log.Reason("strconv.ParseBool"),
-			log.NewValue("error", err),
-		)
-		return err
+	hasPostMortemMeeting := false
+	if app.Calendar != nil {
+		hasPostMortemMeeting, err = strconv.ParseBool(postMortemMeeting)
+		if err != nil {
+			app.Logger.Error(
+				ctx,
+				log.Trace(),
+				log.Reason("strconv.ParseBool"),
+				log.NewValue("error", err),
+			)
+			return err
+		}
 	}
 
 	if hasPostMortemMeeting {
@@ -288,7 +282,6 @@ func createResolveChannelAttachment(inc model.Incident, userName string, event *
 
 	messageText.WriteString("The Incident <#" + inc.ChannelId + "> has been resolved by <@" + userName + ">\n\n")
 	messageText.WriteString("*End date:* <#" + endDateText + ">\n")
-	messageText.WriteString("*Status.io link:* `" + inc.StatusPageUrl + "`\n")
 	messageText.WriteString("*Description:* `" + inc.DescriptionResolved + "`\n")
 	if event == nil {
 		messageText.WriteString("*Post Mortem:* A Post Mortem Meeting was not scheduled, but be sure to fill up the Post Mortem document.\n")
@@ -321,10 +314,6 @@ func createResolveChannelAttachment(inc model.Incident, userName string, event *
 				Value: endDateText,
 			},
 			{
-				Title: "Status.io link",
-				Value: inc.StatusPageUrl,
-			},
-			{
 				Title: "Description",
 				Value: inc.DescriptionResolved,
 			},
@@ -343,7 +332,6 @@ func createResolvePrivateAttachment(inc model.Incident, event *model.Event) slac
 	)
 
 	privateText.WriteString("The Incident <#" + inc.ChannelId + "> has been resolved by you\n\n")
-	privateText.WriteString("*Status.io:* Be sure to update the incident status on" + inc.StatusPageUrl + "\n")
 	if event == nil {
 		privateText.WriteString("*Post Mortem:* A Post Mortem Meeting was not scheduled, but be sure to fill up the Post Mortem document.\n")
 		postMortemMessage = "A Post Mortem Meeting was not scheduled, but be sure to fill up the Post Mortem document."
@@ -358,10 +346,6 @@ func createResolvePrivateAttachment(inc model.Incident, event *model.Event) slac
 		Text:     "",
 		Color:    "#1164A3",
 		Fields: []slack.AttachmentField{
-			{
-				Title: "Status.io",
-				Value: "Be sure to update the incident status on " + inc.StatusPageUrl,
-			},
 			{
 				Title: "Post Mortem",
 				Value: postMortemMessage,

--- a/internal/commands/resolve_test.go
+++ b/internal/commands/resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"hellper/internal/app"
 	"hellper/internal/bot"
 	calendar "hellper/internal/calendar"
 	"hellper/internal/commands"
@@ -22,11 +23,11 @@ type resolveCommandFixture struct {
 	expectError  bool
 	errorMessage string
 
-	ctx            context.Context
-	mockLogger     log.Logger
-	mockClient     bot.Client
-	mockRepository model.IncidentRepository
-	mockCalendar   calendar.Calendar
+	ctx                    context.Context
+	mockLogger             log.Logger
+	mockClient             bot.Client
+	mockIncidentRepository model.IncidentRepository
+	mockCalendar           calendar.Calendar
 
 	triggerID       string
 	channelID       string
@@ -112,7 +113,7 @@ func (f *resolveCommandFixture) setup(t *testing.T) {
 
 	f.mockLogger = loggerMock
 	f.mockClient = clientMock
-	f.mockRepository = repositoryMock
+	f.mockIncidentRepository = repositoryMock
 	f.mockCalendar = calendarMock
 }
 
@@ -128,7 +129,7 @@ func TestResolveIncidentDialog(t *testing.T) {
 		t.Run(fmt.Sprintf("%v-%v", index, f.testName), func(t *testing.T) {
 			f.setup(t)
 
-			err := commands.ResolveIncidentDialog(f.mockClient, f.triggerID)
+			err := commands.ResolveIncidentDialog(&app.App{Client: f.mockClient}, f.triggerID)
 
 			if f.expectError {
 				if err == nil {
@@ -181,7 +182,16 @@ func TestResolveIncidentByDialog(t *testing.T) {
 		t.Run(fmt.Sprintf("%v-%v", index, f.testName), func(t *testing.T) {
 			f.setup(t)
 
-			err := commands.ResolveIncidentByDialog(f.ctx, f.mockClient, f.mockLogger, f.mockRepository, f.mockCalendar, f.incidentDetails)
+			err := commands.ResolveIncidentByDialog(
+				f.ctx,
+				&app.App{
+					Logger:             f.mockLogger,
+					Client:             f.mockClient,
+					IncidentRepository: f.mockIncidentRepository,
+					Calendar:           f.mockCalendar,
+				},
+				f.incidentDetails,
+			)
 
 			if f.expectError {
 				if err == nil {

--- a/internal/model/service_instance.go
+++ b/internal/model/service_instance.go
@@ -2,6 +2,6 @@ package model
 
 // ServiceInstance represents an instance of a service that is running somewhere
 type ServiceInstance struct {
-	ID   int64  `db:"id,omitempty"`
+	ID   string `db:"id,omitempty"`
 	Name string `db:"name,omitempty"`
 }

--- a/internal/model/service_repository.go
+++ b/internal/model/service_repository.go
@@ -5,4 +5,5 @@ import "context"
 // ServiceRepository wraps services data from the database
 type ServiceRepository interface {
 	ListServiceInstances(ctx context.Context) ([]*ServiceInstance, error)
+	GetServiceInstanceOwnerTeamName(ctx context.Context, instanceName string) (string, error)
 }

--- a/internal/model/sql/postgres/schema/V1_create_teams_services_and_namespaces.sql
+++ b/internal/model/sql/postgres/schema/V1_create_teams_services_and_namespaces.sql
@@ -47,3 +47,16 @@ ALTER TABLE public.team_member OWNER TO hellper;
 ALTER TABLE public.service OWNER TO hellper;
 ALTER TABLE public.service_instance OWNER TO hellper;
 ALTER TABLE public.service_instance_stakeholder OWNER TO hellper;
+
+-- TODO: Remove this from here or replace with a more complete bootstrap
+insert into service (name, created_at) values ('Maestro', now())
+insert into service (name, created_at) values ('Matchmaker', now())
+insert into service (name, created_at) values ('Remote Config', now())
+insert into team (name, created_at) values ('Game Services & Analytics - MIRC Squad', now())
+insert into team (name, created_at) values ('Game Services & Analytics - PAC Squad', now())
+insert into team (name, created_at) values ('Tennis Clash', now())
+insert into team (name, created_at) values ('Zooba', now())
+insert into service_instance (name, service_id, owner_team_id, created_at) values ('Zooba', 1, 1, now())
+insert into service_instance (name, service_id, owner_team_id, created_at) values ('Tennis', 1, 1, now())
+insert into service_instance (name, service_id, owner_team_id, created_at) values ('Zooba', 2, 1, now())
+insert into service_instance (name, service_id, owner_team_id, created_at) values ('Tennis', 2, 1, now())

--- a/internal/model/sql/postgres/schema/V1_create_teams_services_and_namespaces.sql
+++ b/internal/model/sql/postgres/schema/V1_create_teams_services_and_namespaces.sql
@@ -49,14 +49,14 @@ ALTER TABLE public.service_instance OWNER TO hellper;
 ALTER TABLE public.service_instance_stakeholder OWNER TO hellper;
 
 -- TODO: Remove this from here or replace with a more complete bootstrap
-insert into service (name, created_at) values ('Maestro', now())
-insert into service (name, created_at) values ('Matchmaker', now())
-insert into service (name, created_at) values ('Remote Config', now())
-insert into team (name, created_at) values ('Game Services & Analytics - MIRC Squad', now())
-insert into team (name, created_at) values ('Game Services & Analytics - PAC Squad', now())
-insert into team (name, created_at) values ('Tennis Clash', now())
-insert into team (name, created_at) values ('Zooba', now())
-insert into service_instance (name, service_id, owner_team_id, created_at) values ('Zooba', 1, 1, now())
-insert into service_instance (name, service_id, owner_team_id, created_at) values ('Tennis', 1, 1, now())
-insert into service_instance (name, service_id, owner_team_id, created_at) values ('Zooba', 2, 1, now())
-insert into service_instance (name, service_id, owner_team_id, created_at) values ('Tennis', 2, 1, now())
+insert into service (name, created_at) values ('Maestro', now());
+insert into service (name, created_at) values ('Matchmaker', now());
+insert into service (name, created_at) values ('Remote Config', now());
+insert into team (name, created_at) values ('Game Services & Analytics - MIRC Squad', now());
+insert into team (name, created_at) values ('Game Services & Analytics - PAC Squad', now());
+insert into team (name, created_at) values ('Tennis Clash', now());
+insert into team (name, created_at) values ('Zooba', now());
+insert into service_instance (name, service_id, owner_team_id, created_at) values ('Zooba', 1, 1, now());
+insert into service_instance (name, service_id, owner_team_id, created_at) values ('Tennis', 1, 1, now());
+insert into service_instance (name, service_id, owner_team_id, created_at) values ('Zooba', 2, 1, now());
+insert into service_instance (name, service_id, owner_team_id, created_at) values ('Tennis', 2, 1, now());

--- a/internal/model/sql/postgres/service_repository.go
+++ b/internal/model/sql/postgres/service_repository.go
@@ -2,9 +2,11 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"hellper/internal/log"
 	"hellper/internal/model"
 	"hellper/internal/model/sql"
+	"strings"
 
 	_ "github.com/lib/pq"
 )
@@ -25,7 +27,7 @@ func NewServiceRepository(logger log.Logger, db sql.DB) model.ServiceRepository 
 // ListServiceInstances returns all service instances registered in the database
 func (r *serviceRepository) ListServiceInstances(ctx context.Context) ([]*model.ServiceInstance, error) {
 	query := `
-	SELECT 
+	SELECT
 		service_instance.id as id,
 		(service.name || '/' || service_instance.name) as name
 	FROM public.service
@@ -55,4 +57,72 @@ func (r *serviceRepository) ListServiceInstances(ctx context.Context) ([]*model.
 	}
 
 	return serviceInstances, nil
+}
+
+// GetServiceInstanceOwner returns the owner team name of a service instance registered in the database
+func (r *serviceRepository) GetServiceInstanceOwnerTeamName(
+	ctx context.Context, instanceName string,
+) (string, error) {
+	names := strings.Split(instanceName, "/")
+	if len(names) < 2 {
+		err := errors.New("Unable to parse instance name #" + instanceName)
+		r.logger.Error(
+			ctx,
+			"postgres/incident-repository.GetServiceInstanceOwnerTeamName ERROR",
+			log.NewValue("instanceName", instanceName),
+			log.NewValue("error", err),
+		)
+		return "", err
+	}
+	serviceName := names[0]
+	serviceInstanceName := names[1]
+
+	query := `
+	SELECT
+    team.name as team_name
+	FROM public.service
+	INNER JOIN public.service_instance on service.id = service_instance.service_id
+	INNER JOIN public.team on service_instance.owner_team_id = team.id
+  WHERE service.name = $1 AND service_instance.name = $2
+	`
+
+	rows, err := r.db.Query(query, serviceName, serviceInstanceName)
+	if err != nil {
+		r.logger.Error(
+			ctx,
+			"postgres/service-repository.GetServiceInstanceOwnerTeamName Query ERROR",
+			log.NewValue("instanceName", instanceName),
+			log.NewValue("serviceName", serviceName),
+			log.NewValue("serviceInstanceName", serviceInstanceName),
+			log.NewValue("Error", err),
+		)
+		return "", err
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		err = errors.New("Owner team of service instance" + instanceName + " not found")
+		r.logger.Error(
+			ctx,
+			"postgres/incident-repository.GetServiceInstanceOwnerTeamName ERROR",
+			log.NewValue("instanceName", instanceName),
+			log.NewValue("serviceName", serviceName),
+			log.NewValue("serviceInstanceName", serviceInstanceName),
+			log.NewValue("error", err),
+		)
+		return "", err
+	}
+
+	var ownerTeamName string
+	rows.Scan(&ownerTeamName)
+	r.logger.Info(
+		ctx,
+		"postgres/incident-repository.GetServiceInstanceOwnerTeamName SUCCESS",
+		log.NewValue("instanceName", instanceName),
+		log.NewValue("serviceName", serviceName),
+		log.NewValue("serviceInstanceName", serviceInstanceName),
+		log.NewValue("ownerTeamName", ownerTeamName),
+	)
+
+	return ownerTeamName, nil
 }


### PR DESCRIPTION
### Description
The forms are currently too verbose. So, we are making them more minimalist.

Cards:
- https://trello.com/c/EVL6MOIJ/43-resolveincident-remover-statusio
- https://trello.com/c/spoMFKl5/49-resolveincident-validar-exist%C3%AAncia-de-calendar
- https://trello.com/c/7ZCkipnE/46-closeincident-remover-users-do-formul%C3%A1rio
- https://trello.com/c/xtzP1Mte/48-closeincident-permitir-atualizar-datas-diretamente-no-comando-ao-inv%C3%A9s-de-esperar-que-o-updatedates-seja-invocado-antes
- https://trello.com/c/8p6C9gh8/38-closeincident-remover-ownerteam-do-formul%C3%A1rio

### How to test?
Make the regular incident flow.

### Expected behavior
Should work normally and alloew